### PR TITLE
Only target develop for pipelines

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,6 @@ name: pr
 on:
   pull_request:
     branches:
-      - main
       - develop
 
 jobs:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -19,7 +19,6 @@ name: push
 on:
   push:
     branches:
-      - main
       - develop
 
 jobs:

--- a/build/Build.CI.GitHubActions.cs
+++ b/build/Build.CI.GitHubActions.cs
@@ -9,7 +9,7 @@ using Nuke.Common.CI.GitHubActions;
 	EnableGitHubToken = false,
 	FetchDepth = 0, // Only a single commit is fetched by default, for the ref/SHA that triggered the workflow. Make sure to fetch whole git history, in order to get GitVersion to work.
 	InvokedTargets = new[] { nameof(Pack) },
-	OnPullRequestBranches = new[] { "main", "develop" },
+	OnPullRequestBranches = new[] { "develop" },
 	PublishArtifacts = true)]
 [GitHubActions(
 	"push",
@@ -19,7 +19,7 @@ using Nuke.Common.CI.GitHubActions;
 	EnableGitHubToken = false,
 	FetchDepth = 0, // Only a single commit is fetched by default, for the ref/SHA that triggered the workflow. Make sure to fetch whole git history, in order to get GitVersion to work.
 	InvokedTargets = new[] { nameof(Pack) },
-	OnPushBranches = new[] { "main", "develop" },
+	OnPushBranches = new[] { "develop" },
 	PublishArtifacts = true)]
 [GitHubActions(
 	"publish",


### PR DESCRIPTION
Due to the new pipeline, it doesn't make much sense to keep both a `master` and a `develop` branch, so this PR changes to pipelines to only trigger on develop. This way, we can obsolete the `master` branch and streamline the release process.